### PR TITLE
DTD-466: updated one test using postcode in the wrong format

### DIFF
--- a/src/test/resources/features/ifs/SupressionByPostCode.feature
+++ b/src/test/resources/features/ifs/SupressionByPostCode.feature
@@ -220,7 +220,6 @@ Feature: Suppression by Postcode
     Examples:
       | subDistrict | postCode |
       | AA9A        | AA9A 9AA |
-      | A9A         | A9A 9AA  |
       | A9          | A9 9AA   |
       | A99         | A99 9AA  |
       | AA9         | AA9 9AA  |


### PR DESCRIPTION
Given the last changes (DTD-466) for IFS some postcodes won't be accepted if in the wrong format