### PR TITLE
DTD-568: TTP uses debtItemChargeId so keeping it that way (PEGA uses …

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/api/models/DebtCalculation.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/models/DebtCalculation.scala
@@ -8,7 +8,7 @@ package uk.gov.hmrc.test.api.models
 import play.api.libs.json.{Json, OFormat}
 
 case class DebtCalculation(
-                            debtItemChargeID: String,
+                            debtItemChargeId: String,
                             interestBearing: Boolean,
                             interestDueDailyAccrual: BigDecimal,
                             interestDueDutyTotal: BigDecimal,

--- a/src/test/scala/uk/gov/hmrc/test/api/models/sol/IfsResponse.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/models/sol/IfsResponse.scala
@@ -26,7 +26,7 @@ object DebtCalculationWindow {
 }
 
 final case class DebtCalculationItem(
-  debtItemChargeID: String,
+  debtItemChargeId: String,
   interestBearing: Boolean,
   numberOfChargeableDays: Long,
   interestDueDailyAccrual: Int,


### PR DESCRIPTION
…debtItemChargeID)