### PR TITLE
DTD-1125: Bridge tool - Skip calling service in QA and use EIS API directly

### DIFF
--- a/bridge-tool/src/main/scala/Errors.scala
+++ b/bridge-tool/src/main/scala/Errors.scala
@@ -25,7 +25,7 @@ sealed abstract class BridgeToolError {
       case MissingURL(badDetails: RequestDetail) =>
         s"Missing URL from request details; details: $badDetails"
 
-      case MissingQAToken() =>
+      case MissingQAToken =>
         s"Missing QAToken from local environment"
 
       case BadMethod(badDetails: RequestDetail) =>
@@ -55,7 +55,7 @@ object BridgeToolError {
   final case class BadResponse(error: Response) extends BridgeToolError
   final case class BadResponseWithDetails(error: Response, details: RequestDetail) extends BridgeToolError
   final case class MissingURL(badDetails: RequestDetail) extends BridgeToolError
-  final case class MissingQAToken() extends BridgeToolError
+  case object MissingQAToken extends BridgeToolError
   final case class BadMethod(badDetails: RequestDetail) extends BridgeToolError
   final case class Decode(badObject: String, error: CirceError) extends BridgeToolError
   case object NoRequestsToProcess extends BridgeToolError

--- a/bridge-tool/src/main/scala/Errors.scala
+++ b/bridge-tool/src/main/scala/Errors.scala
@@ -25,6 +25,9 @@ sealed abstract class BridgeToolError {
       case MissingURL(badDetails: RequestDetail) =>
         s"Missing URL from request details; details: $badDetails"
 
+      case MissingQAToken() =>
+        s"Missing QAToken from local environment"
+
       case BadMethod(badDetails: RequestDetail) =>
         badDetails.method match {
           case Some(badMethod) =>
@@ -52,6 +55,7 @@ object BridgeToolError {
   final case class BadResponse(error: Response) extends BridgeToolError
   final case class BadResponseWithDetails(error: Response, details: RequestDetail) extends BridgeToolError
   final case class MissingURL(badDetails: RequestDetail) extends BridgeToolError
+  final case class MissingQAToken() extends BridgeToolError
   final case class BadMethod(badDetails: RequestDetail) extends BridgeToolError
   final case class Decode(badObject: String, error: CirceError) extends BridgeToolError
   case object NoRequestsToProcess extends BridgeToolError

--- a/bridge-tool/src/main/scala/Main.scala
+++ b/bridge-tool/src/main/scala/Main.scala
@@ -73,7 +73,7 @@ def retrieveExternalTestToken(): Result[TokenResponse] =
 def retrieveQAToken(): Result[TokenResponse] =
   sys.env.get("ADMIN_QA_TOKEN") match {
     case Some(value) => Right(TokenResponse(value))
-    case None        => Left(BridgeToolError.MissingQAToken())
+    case None        => Left(BridgeToolError.MissingQAToken)
   }
 
 def retrieveAllUnprocessedRequests(token: TokenResponse): Result[List[RequestDetail]] =


### PR DESCRIPTION
**Problem:** 
Error output of the bridge tool currently looks like this
`{
	"failures": [
		{
			"code": "BAD_IF_RESPONSE",
			"reason": "Bad response from IF; got status: 400, and got reason {\"failures\":[{\"code\":\"INVALID_CORRELATIONID\",\"reason\":\"Submission has not passed validation. Invalid header CorrelationId.\"}]}"
		}
	]
}`

**Solution:** 
Use an endpoint that calls directly to the service rather than IF -> QA -> service
This requires the stub's endpoints to be updated to match https://github.com/hmrc/debt-transformation-stub/pull/87, e.g.

Old: https://api.qa.tax.service.gov.uk/individuals/field-collections/charges
New: https://admin.qa.tax.service.gov.uk/ifs/individuals/debts/field-collections/VRN/975839485/charge