### PR TITLE
DTD-3244: Set security assement flag for ATs to false

### DIFF
--- a/run_interest_forecasting_api_tests.sh
+++ b/run_interest_forecasting_api_tests.sh
@@ -20,4 +20,4 @@ if [[ "$status_code" -ne 200 ]] ; then
 fi
 sleep 2
 
-sbt -Denvironment="$environment" -Dcucumber.options="--tags '$tags'" clean 'testOnly uk.gov.hmrc.test.api.cucumber.runner.InterestForecastingApiTestRunner'
+sbt -Dsecurity.assessment="false" -Denvironment="$environment" -Dcucumber.options="--tags '$tags'" clean 'testOnly uk.gov.hmrc.test.api.cucumber.runner.InterestForecastingApiTestRunner'

--- a/run_statement_of_liability_api_pega_contract_tests.sh
+++ b/run_statement_of_liability_api_pega_contract_tests.sh
@@ -10,4 +10,4 @@ fi
 
 echo "*** running on $environment for tags '$tags' ***"
 
-sbt -Denvironment="$environment" -Dcucumber.options="--tags '$tags'" clean 'testOnly uk.gov.hmrc.test.api.cucumber.runner.StatementOfLiabilityApiPegaTestRunner'
+sbt -Dsecurity.assessment="false" -Denvironment="$environment" -Dcucumber.options="--tags '$tags'" clean 'testOnly uk.gov.hmrc.test.api.cucumber.runner.StatementOfLiabilityApiPegaTestRunner'

--- a/run_statement_of_liability_api_tests.sh
+++ b/run_statement_of_liability_api_tests.sh
@@ -10,4 +10,4 @@ fi
 
 echo "*** running on $environment for tags '$tags' ***"
 
-sbt -Denvironment="$environment" -Dcucumber.options="--tags '$tags'" clean 'testOnly uk.gov.hmrc.test.api.cucumber.runner.StatementOfLiabilityApiTestRunner'
+sbt -Dsecurity.assessment="false" -Denvironment="$environment" -Dcucumber.options="--tags '$tags'" clean 'testOnly uk.gov.hmrc.test.api.cucumber.runner.StatementOfLiabilityApiTestRunner'


### PR DESCRIPTION
-Dsecurity.assessment should have been set to false by default on Jenkins, but it was true.