### PR TITLE
Dtd 3523: Update SoL with new penalty reform charges

### DIFF
--- a/src/test/resources/features/sol/SolSADebtDetailsRequest.feature
+++ b/src/test/resources/features/sol/SolSADebtDetailsRequest.feature
@@ -135,3 +135,49 @@ Feature: Statement of liability Debt details for Self Assessment Debts
     And the 1st sol debt summary will contain duties
       | subTrans | unpaidAmountDuty | combinedDailyAccrual | interestBearing | interestOnlyIndicator |
       | 1554     | 500000           | 0                    | false           | true                  |
+
+  @DTD-3523
+  Scenario Outline: 9. SA customer statement of liability - Penalty Reform Charge - Interest bearing debt
+    Given debt details
+      | solType | debtId   | mainTrans   | subTrans   | interestRequestedTo |
+      | UI      | <debtId> | <mainTrans> | <subTrans> | 2021-08-10          |
+    When a debt statement of liability is requested
+    Then service returns debt statement of liability data
+      | amountIntTotal | combinedDailyAccrual |
+      | 504629         | 35                   |
+    And the 1st sol debt summary will contain
+      | debtId   | mainTrans   | debtTypeDescription   | interestDueDebtTotal | totalAmountIntDebt | combinedDailyAccrual |
+      | <debtId> | <mainTrans> | Penalty reform charge | 4629                 | 504629             | 35                   |
+    And the 1st sol debt summary will contain duties
+      | subTrans   | unpaidAmountDuty | combinedDailyAccrual | interestBearing   | interestOnlyIndicator   |
+      | <subTrans> | 500000           | 35                   | <interestBearing> | <interestOnlyIndicator> |
+    Examples:
+      | debtId     | mainTrans | subTrans | interestBearing | interestOnlyIndicator |
+      | debtSA0017 | 4027      | 1080     | true            | false                 |
+      | debtSA0018 | 4028      | 1085     | true            | false                 |
+      | debtSA0019 | 4029      | 1090     | true            | false                 |
+      | debtSA0020 | 4031      | 1095     | true            | false                 |
+      | debtSA0021 | 4032      | 1090     | true            | false                 |
+      | debtSA0022 | 4033      | 1095     | true            | false                 |
+
+  @DTD-3523
+  Scenario Outline: 10. SA customer statement of liability - Penalty Reform Charge - Non Interest bearing debt
+    Given debt details
+      | solType | debtId   | mainTrans   | subTrans   | interestRequestedTo |
+      | UI      | <debtId> | <mainTrans> | <subTrans> | 2021-08-10          |
+    When a debt statement of liability is requested
+    Then service returns debt statement of liability data
+      | amountIntTotal | combinedDailyAccrual |
+      | 500000         | 0                    |
+    And the 1st sol debt summary will contain
+      | debtId   | mainTrans   | debtTypeDescription   | interestDueDebtTotal | totalAmountIntDebt | combinedDailyAccrual |
+      | <debtId> | <mainTrans> | Penalty reform charge | 0                    | 500000             | 0                    |
+    And the 1st sol debt summary will contain duties
+      | subTrans   | unpaidAmountDuty | combinedDailyAccrual | interestBearing   | interestOnlyIndicator   |
+      | <subTrans> | 500000           | 0                    | <interestBearing> | <interestOnlyIndicator> |
+    Examples:
+      | debtId     | mainTrans | subTrans | interestBearing | interestOnlyIndicator |
+      | debtSA0023 | 6010      | 1611     | false           | true                  |
+      | debtSA0024 | 6010      | 2090     | false           | true                  |
+      | debtSA0025 | 6010      | 2095     | false           | true                  |
+      | debtSA0026 | 6010      | 2096     | false           | true                  |

--- a/src/test/scala/uk/gov/hmrc/test/api/cucumber/hooks/IfsRuleHook.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/cucumber/hooks/IfsRuleHook.scala
@@ -28,7 +28,6 @@ class IfsRuleHook extends ScalaDsl with LazyLogging {
     println("before block starts running")
     ScenarioContext.reset()
 
-
     println("before block finished running")
   }
 

--- a/src/test/scala/uk/gov/hmrc/test/api/cucumber/stepdefs/ifs/InterestForecastingSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/cucumber/stepdefs/ifs/InterestForecastingSteps.scala
@@ -39,19 +39,17 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
   }
 
   When("a rule has been updated") { (dataTable: DataTable) =>
-    val asmapTransposed = dataTable.transpose().asMap(classOf[String], classOf[String])
-    val responseGEtRules = getAllRules
-    val collection = Json.parse(responseGEtRules.body).as[GetRulesResponse]
+    val asmapTransposed        = dataTable.transpose().asMap(classOf[String], classOf[String])
+    val responseGEtRules       = getAllRules
+    val collection             = Json.parse(responseGEtRules.body).as[GetRulesResponse]
     val newRules: List[String] = collection.rules.find(_.enabled) match {
       case Some(activeRules) =>
         val rules = activeRules.rules.filterNot(vl =>
           vl.contains(asmapTransposed.get("mainTrans")) && vl.contains(asmapTransposed.get("subTrans"))
         )
-        rules ++ List(s"IF mainTrans == '${asmapTransposed.get("mainTrans")}' AND subTrans == '${
-          asmapTransposed
-            .get("subTrans")
-        }' -> intRate = ${asmapTransposed.get("intRate")} AND interestOnlyDebt = false")
-      case _ => None.toList
+        rules ++ List(s"IF mainTrans == '${asmapTransposed.get("mainTrans")}' AND subTrans == '${asmapTransposed
+          .get("subTrans")}' -> intRate = ${asmapTransposed.get("intRate")} AND interestOnlyDebt = false")
+      case _                 => None.toList
     }
 
     postNewRulesTable(Json.toJson(CreateRuleRequest(newRules)).toString())
@@ -60,17 +58,17 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
   Given("the current set of rules") { () =>
     val responseGEtRules = getAllRules
 
-    val collection = Json.parse(responseGEtRules.body).as[GetRulesResponse]
+    val collection        = Json.parse(responseGEtRules.body).as[GetRulesResponse]
     val existingProdRules = collection.rules.find(_.version == 1)
     existingProdRules match {
       case Some(rules) => postNewRulesTable(Json.toJson(CreateRuleRequest(rules.rules)).toString())
-      case _ => println("Error. No rules with version 1 found")
+      case _           => println("Error. No rules with version 1 found")
     }
   }
 
   Given("(.*) debt items") { (numberItems: Int) =>
     var debtItems: String = null
-    var n = 0
+    var n                 = 0
 
     while (n < numberItems) {
       val debtItem = getBodyAsString("debtItem")
@@ -96,7 +94,7 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
 
   Given("(.*) debt items where interest rate changes from 3\\.0 to 3\\.25") { (numberItems: Int) =>
     var debtItems: String = null
-    var n = 0
+    var n                 = 0
 
     while (n < numberItems) {
       val debtItem = getBodyAsString("debtItem")
@@ -129,7 +127,7 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
   }
 
   When("the debt item(s) is sent to the ifs service") { () =>
-    val request = ScenarioContext.get("debtItems").toString
+    val request  = ScenarioContext.get("debtItems").toString
     println(s"IFS REQUEST --> $request")
     val response = getDebtCalculation(request)
     println(s"IFS RESPONSE --> ${response.body}")
@@ -137,7 +135,7 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
   }
 
   When("the debt interest type request is sent to the ifs service") { () =>
-    val request = ScenarioContext.get("debtInterestTypes").toString
+    val request  = ScenarioContext.get("debtInterestTypes").toString
     println(s"IFS REQUEST --> $request")
     val response = getDebtInterestTypeRequestBody(request)
     println(s"IFS Service RESPONSE --> ${response.body}")
@@ -146,7 +144,7 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
   }
 
   Then("the ifs service wilL return a total debts summary of") { (dataTable: DataTable) =>
-    val asMapTransposed = dataTable.transpose().asMap(classOf[String], classOf[String])
+    val asMapTransposed                = dataTable.transpose().asMap(classOf[String], classOf[String])
     val response: StandaloneWSResponse = ScenarioContext.get("response")
 
     val responseBody = Json.parse(response.body).as[DebtCalculationsSummary]
@@ -198,7 +196,7 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
   }
 
   Then("the ([0-9]\\d*)(?:st|nd|rd|th) debt summary will contain") { (index: Int, dataTable: DataTable) =>
-    val asMapTransposed = dataTable.transpose().asMap(classOf[String], classOf[String])
+    val asMapTransposed                = dataTable.transpose().asMap(classOf[String], classOf[String])
     val response: StandaloneWSResponse = ScenarioContext.get("response")
     response.status should be(200)
 
@@ -271,14 +269,14 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
 
   Then("""the ifs service will respond with (.*)""") { (expectedMessage: String) =>
     val response: StandaloneWSResponse = ScenarioContext.get("response")
-    response.body should include(expectedMessage)
+    response.body   should include(expectedMessage)
     response.status should be(400)
   }
 
   Then("the ifs service will respond with") { (dataTable: DataTable) =>
-    val asMapTransposed = dataTable.transpose().asMap(classOf[String], classOf[String])
+    val asMapTransposed                = dataTable.transpose().asMap(classOf[String], classOf[String])
     val response: StandaloneWSResponse = ScenarioContext.get("response")
-    val errorResponse = Json.parse(response.body).as[Errors]
+    val errorResponse                  = Json.parse(response.body).as[Errors]
 
     locally {
       val fieldName = "statusCode"
@@ -312,7 +310,7 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
 
   Then("the ([0-9])(?:st|nd|rd|th) debt summary will have calculation windows") {
     (summaryIndex: Int, dataTable: DataTable) =>
-      val asMapTransposed = dataTable.asMaps(classOf[String], classOf[String])
+      val asMapTransposed                = dataTable.asMaps(classOf[String], classOf[String])
       val response: StandaloneWSResponse = ScenarioContext.get("response")
 
       asMapTransposed.asScala.zipWithIndex.foreach { case (window, index) =>
@@ -432,10 +430,9 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
       }
   }
 
-
   Then("the ([0-9])(?:st|nd|rd|th) debt summary will have suppression applied calculation windows") {
     (summaryIndex: Int, dataTable: DataTable) =>
-      val asMapTransposed = dataTable.asMaps(classOf[String], classOf[String])
+      val asMapTransposed                = dataTable.asMaps(classOf[String], classOf[String])
       val response: StandaloneWSResponse = ScenarioContext.get("response")
 
       asMapTransposed.asScala.zipWithIndex.foreach { case (window, index) =>
@@ -447,7 +444,6 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
 
         if (calculationWindows.isDefinedAt(index)) {
           calculationWindows(index).suppressionsApplied.getOrElse(List.empty).foreach { suppression =>
-
             locally {
               val fieldName = "dateFrom"
               if (window.containsKey(fieldName)) {
@@ -461,13 +457,10 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
               val fieldName = "dateTo"
               if (window.containsKey(fieldName)) {
                 withClue(s"$fieldName: ") {
-                  suppression.dateTo .toString shouldBe Some(window.get(fieldName)).toString
+                  suppression.dateTo.toString shouldBe Some(window.get(fieldName)).toString
                 }
               }
             }
-
-
-
 
             locally {
               val fieldName = "reasonDesc"
@@ -508,7 +501,6 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
         }
       }
   }
-
 
   Then("Ifs service returns response code (.*)") { (expectedCode: Int) =>
     val response: StandaloneWSResponse = ScenarioContext.get("response")
@@ -590,16 +582,16 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
       }
   }
 
-
   Then("the ([0-9])(?:st|nd|rd|th) debt applied suppression summary contains values as") {
     (summaryIndex: Int, dataTable: DataTable) =>
-      val asMapTransposed = dataTable.asMaps(classOf[String], classOf[String])
+      val asMapTransposed                = dataTable.asMaps(classOf[String], classOf[String])
       val response: StandaloneWSResponse = ScenarioContext.get("response")
 
       asMapTransposed.asScala.zipWithIndex.foreach { case (window, index) =>
         val maybeSuppression = for {
-          debt <- Json.parse(response.body).as[DebtCalculationsSummary].debtCalculations.lift(summaryIndex - 1) // Safe index
-          windowData <- debt.calculationWindows.lift(index)
+          debt        <-
+            Json.parse(response.body).as[DebtCalculationsSummary].debtCalculations.lift(summaryIndex - 1) // Safe index
+          windowData  <- debt.calculationWindows.lift(index)
           suppression <- windowData.suppressionApplied
         } yield suppression
 
@@ -634,12 +626,11 @@ class InterestForecastingSteps extends ScalaDsl with EN with Eventually with Mat
 
           case None if window.containsKey("reason") && window.get("reason").toString.nonEmpty =>
             fail(s"Expected suppressionApplied for debt index $summaryIndex and window $index, but it was missing.")
-          case _ =>
+          case _                                                                              =>
 
         }
       }
   }
-
 
   def getCountOfCalculationWindows(summaryIndex: Int): Int = {
     val response: StandaloneWSResponse = ScenarioContext.get("response")

--- a/src/test/scala/uk/gov/hmrc/test/api/cucumber/stepdefs/suppressions/SuppresionStepDefs.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/cucumber/stepdefs/suppressions/SuppresionStepDefs.scala
@@ -33,7 +33,7 @@ class SuppresionStepDefs extends ScalaDsl with EN with Eventually with Matchers 
     val requestJson = ScenarioContext.get[String]("suppressionsJson")
     println(s"suppression data REQUEST ---------> $requestJson")
     val response    = updateSuppressionData(requestJson)
-    withClue(s"Incorrect status with body : ${response.body}\n\n"){
+    withClue(s"Incorrect status with body : ${response.body}\n\n") {
       response.status should be(200)
     }
 

--- a/src/test/scala/uk/gov/hmrc/test/api/models/CalculationWindow.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/models/CalculationWindow.scala
@@ -31,7 +31,7 @@ case class CalculationWindow(
   breathingSpaceApplied: Boolean,
   unpaidAmountWindow: BigDecimal,
   suppressionApplied: Option[SuppressionApplied],
-  suppressionsApplied: Option [List[SuppressionsApplied]]
+  suppressionsApplied: Option[List[SuppressionsApplied]]
 )
 
 case class SuppressionApplied(reason: String, description: String, code: String)
@@ -40,15 +40,15 @@ object SuppressionApplied {
 }
 
 case class SuppressionsApplied(
-                                dateFrom: String,
-                                dateTo: Option[String],
-                                reason: String,
-                                reasonDesc: String,
-                                postcode: Option[String],
-                                mainTrans: Option[String],
-                                subTrans: Option[String],
-                                periodEnd: Option[String]
-                              )
+  dateFrom: String,
+  dateTo: Option[String],
+  reason: String,
+  reasonDesc: String,
+  postcode: Option[String],
+  mainTrans: Option[String],
+  subTrans: Option[String],
+  periodEnd: Option[String]
+)
 object SuppressionsApplied {
   implicit val formatCalculationWindow: OFormat[SuppressionsApplied] = Json.format[SuppressionsApplied]
 }

--- a/src/test/scala/uk/gov/hmrc/test/api/models/SuppressionInformation.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/models/SuppressionInformation.scala
@@ -20,15 +20,15 @@ import play.api.libs.json.{Json, OFormat}
 
 case class SuppressionInformation(
   dateFrom: String,
-  dateTo:Option[String],
+  dateTo: Option[String],
   reason: String,
   reasonDesc: String,
-  suppressionChargeDescription:String,
+  suppressionChargeDescription: String,
   postcode: Option[String],
   mainTrans: Option[String],
   subTrans: Option[String],
   checkPeriodEnd: Option[Boolean]
-                                 )
+)
 object SuppressionInformation {
   implicit val format: OFormat[SuppressionInformation] = Json.format[SuppressionInformation]
 }

--- a/src/test/scala/uk/gov/hmrc/test/api/models/SuppressionRequest.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/models/SuppressionRequest.scala
@@ -18,8 +18,7 @@ package uk.gov.hmrc.test.api.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class SuppressionRequest(suppressions: Seq[SuppressionInformation]
-)
+case class SuppressionRequest(suppressions: Seq[SuppressionInformation])
 
 object SuppressionRequest {
   implicit val format: OFormat[SuppressionRequest] = Json.format[SuppressionRequest]

--- a/src/test/scala/uk/gov/hmrc/test/api/requests/IFSInstalmentCalculationRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/requests/IFSInstalmentCalculationRequests.scala
@@ -55,17 +55,17 @@ object IFSInstalmentCalculationRequests extends ScalaDsl with EN with Eventually
     var debtItemCharges = ""
 
     asMapTransposed.zipWithIndex.foreach { case (debtItemCharge, index) =>
-      val periodEnd = if (debtItemCharge.containsKey("periodEnd")) {
+      val periodEnd         = if (debtItemCharge.containsKey("periodEnd")) {
         s"""
            |,"periodEnd": "${debtItemCharge.get("periodEnd")}"
            |""".stripMargin
       } else ""
-      val interestStartDate = if (debtItemCharge.containsKey("interestStartDate") ) {
-        if(debtItemCharge.get("interestStartDate").equals("DateInFuture")) {
+      val interestStartDate = if (debtItemCharge.containsKey("interestStartDate")) {
+        if (debtItemCharge.get("interestStartDate").equals("DateInFuture")) {
           s"""
              |,"interestStartDate": "${LocalDate.now().plusDays(15)}"
              |""".stripMargin
-        }else {
+        } else {
           s"""
              |,"interestStartDate": "${debtItemCharge.get("interestStartDate")}"
              |""".stripMargin

--- a/src/test/scala/uk/gov/hmrc/test/api/requests/SuppressionRulesRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/requests/SuppressionRulesRequests.scala
@@ -272,14 +272,14 @@ object SuppressionRulesRequests extends ScalaDsl with EN with Eventually with Ma
   }
 
   def addSuppressionCriteria(dataTable: DataTable): Unit = {
-    val rows= dataTable.asMaps[String,String](classOf[String], classOf[String]).asScala.map(_.asScala)
+    val rows            = dataTable.asMaps[String, String](classOf[String], classOf[String]).asScala.map(_.asScala)
     var suppressionInfo = List[SuppressionInformation]()
 
     rows.foreach { supInfo =>
-      val dateFrom  =supInfo("dateFrom")
-      val dateTo= supInfo.get("dateTo")
-      val reason= supInfo("reason")
-      val reasonDesc = supInfo("reasonDesc")
+      val dateFrom                     = supInfo("dateFrom")
+      val dateTo                       = supInfo.get("dateTo")
+      val reason                       = supInfo("reason")
+      val reasonDesc                   = supInfo("reasonDesc")
       val suppressionChargeDescription = supInfo("suppressionChargeDescription")
       val mainTrans                    = supInfo.get("mainTrans").filter(_.nonEmpty)
       val subTrans                     = supInfo.get("subTrans").filter(_.nonEmpty)

--- a/src/test/scala/uk/gov/hmrc/test/api/utils/ScenarioContext.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/utils/ScenarioContext.scala
@@ -33,7 +33,6 @@ object ScenarioContext {
       .fold(throw new Exception(s"Key $key not found in scenario context"))(_.asInstanceOf[T])
 
   def remove(key: String): Unit = scenarioValues = scenarioValues - key
-  def reset(): Unit = {
+  def reset(): Unit             =
     scenarioValues = Map.empty[String, Any]
-  }
 }


### PR DESCRIPTION
Added tests for DTD-3523 - New Penalty Reform Charges.

One test has failed when running all SoL ATs, which I have looked into and seems to have already been failing before this change has been made (ran the same test against main and it still fails).
<img width="1398" height="382" alt="image" src="https://github.com/user-attachments/assets/11a4ae25-921d-4835-adbf-728253822966" />

All other SoL AT tests have passed. I have added automated tests to get a good coverage for new charges, and manually tested the rest of the combinations highlighted within the spreadsheet attached to [DTD-3523](https://jira.tools.tax.service.gov.uk/browse/DTD-3523).

Also ran scalaFmt which tidied up spacing on existing files.