### PR TITLE
DTD-4478 - Removed tests already covered in UT/IT or other AT's

### DIFF
--- a/src/test/resources/features/ifs/SuppressionEdgeCases.feature
+++ b/src/test/resources/features/ifs/SuppressionEdgeCases.feature
@@ -27,66 +27,6 @@ Feature: Suppression - Edge cases
       | 2022-04-05 | 2022-04-05 | 1            | 0.0          | 0                       | 0                 | 500000               | 500000             | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
       | 2022-04-06 | 2022-05-23 | 48           | 3.25         | 44                      | 2136              | 500000               | 502136             | false                 |             |             |                                      |
 
-
-  Scenario: Suppression, interest rate change after suppression ends
-    Given suppression configuration data is created
-      | dateFrom   | dateTo     | reason      | reasonDesc | suppressionChargeDescription | mainTrans  |
-      | 2022-02-21 | 2022-04-04 | LEGISLATIVE | COVID      | SA-Suppression               | 1535       |
-    When suppression configuration is sent to ifs service
-    And a debt item
-      | originalAmount | interestStartDate | interestRequestedTo | mainTrans | subTrans |
-      | 500000         | 2022-02-01        | 2022-07-06          | 1535      | 1000     |
-    And the debt item has no payment history
-    And no breathing spaces have been applied to the debt item
-    And the customer has post codes
-      | postCode | postCodeDate |
-      | EC2M 2LS | 2020-07-06   |
-    When the debt item is sent to the ifs service
-    Then the ifs service wilL return a total debts summary of
-      | combinedDailyAccrual | interestDueCallTotal | amountIntTotal | unpaidAmountTotal | amountOnIntDueTotal |
-      | 51                   | 5011                 | 505011         | 500000            | 500000              |
-    And the 1st debt summary will contain
-      | interestBearing | numberChargeableDays | interestDueDailyAccrual | interestDueDutyTotal | unpaidAmountDuty | totalAmountIntDuty | amountOnIntDueDuty | interestOnlyIndicator |
-      | true            | 112                  | 51                      | 5011                 | 500000           | 505011             | 500000             | false                 |
-    And the 1st debt summary will have calculation windows
-      | periodFrom | periodTo   | numberOfDays | interestRate | interestDueDailyAccrual | interestDueWindow | amountOnIntDueWindow | unpaidAmountWindow | breathingSpaceApplied | reason      | description | code                                 |
-      | 2022-02-01 | 2022-02-20 | 19           | 2.75         | 37                      | 715               | 500000               | 500715             | false                 |             |             |                                      |
-      | 2022-02-21 | 2022-04-04 | 43           | 0.0          | 0                       | 0                 | 500000               | 500000             | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
-      | 2022-04-05 | 2022-05-23 | 49           | 3.25         | 44                      | 2181              | 500000               | 502181             | false                 |             |             |                                      |
-      | 2022-05-24 | 2022-07-04 | 42           | 3.5          | 47                      | 2013              | 500000               | 502013             | false                 |             |             |                                      |
-      | 2022-07-05 | 2022-07-06 | 2            | 3.75         | 51                      | 102               | 500000               | 500102             | false                 |             |             |                                      |
-
-
-  Scenario: Suppression - interest rate change before suppression
-    Given suppression configuration data is created
-      | dateFrom   | dateTo     | reason      | reasonDesc | suppressionChargeDescription | mainTrans |
-      | 2022-01-07 | 2022-03-05 | LEGISLATIVE | COVID      | SA-Suppression               | 1535      |
-    When suppression configuration is sent to ifs service
-    And a debt item
-      | originalAmount | interestStartDate | interestRequestedTo | mainTrans | subTrans |
-      | 500000         | 2022-01-01        | 2022-07-06          | 1535      | 1000     |
-    And the debt item has no payment history
-    And no breathing spaces have been applied to the debt item
-    And the customer has post codes
-      | postCode | postCodeDate |
-      | EC2M 2LS | 2020-07-06   |
-    When the debt item is sent to the ifs service
-    Then the ifs service wilL return a total debts summary of
-      | combinedDailyAccrual | interestDueCallTotal | amountIntTotal | unpaidAmountTotal | amountOnIntDueTotal |
-      | 51                   | 5706                 | 505706         | 500000            | 500000              |
-    And the 1st debt summary will contain
-      | interestBearing | numberChargeableDays | interestDueDailyAccrual | interestDueDutyTotal | unpaidAmountDuty | totalAmountIntDuty | amountOnIntDueDuty | interestOnlyIndicator |
-      | true            | 128                  | 51                      | 5706                 | 500000           | 505706             | 500000             | false                 |
-    And the 1st debt summary will have calculation windows
-      | periodFrom | periodTo   | numberOfDays | interestRate | interestDueDailyAccrual | interestDueWindow | amountOnIntDueWindow | unpaidAmountWindow | breathingSpaceApplied | reason      | description | code                                 |
-      | 2022-01-01 | 2022-01-06 | 5            | 2.6          | 35                      | 178               | 500000               | 500178             | false                 |             |             |                                      |
-      | 2022-01-07 | 2022-02-20 | 45           | 0.0          | 0                       | 0                 | 500000               | 500000             | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
-      | 2022-02-21 | 2022-03-05 | 13           | 0.0          | 0                       | 0                 | 500000               | 500000             | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
-      | 2022-03-06 | 2022-04-04 | 30           | 3.0          | 41                      | 1232              | 500000               | 501232             | false                 |             |             |                                      |
-      | 2022-04-05 | 2022-05-23 | 49           | 3.25         | 44                      | 2181              | 500000               | 502181             | false                 |             |             |                                      |
-      | 2022-05-24 | 2022-07-04 | 42           | 3.5          | 47                      | 2013              | 500000               | 502013             | false                 |             |             |                                      |
-
-
   Scenario: Suppression, interest rate change before and after suppression
     Given suppression configuration data is created
       | dateFrom   | dateTo     | reason      | reasonDesc | suppressionChargeDescription | mainTrans |

--- a/src/test/resources/features/ifs/Supression.feature
+++ b/src/test/resources/features/ifs/Supression.feature
@@ -104,33 +104,6 @@ Feature: Suppression
       | 2024-03-01 | 2024-03-20 | 19           | 0.0          | 0                       | 500000             | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
       | 2024-03-21 | 2024-07-06 | 108          | 6.5          | 88                      | 509590             | false                 |             |             |                                      |
 
-
-  Scenario: Suppression applied - periodEnd
-    Given suppression configuration data is created
-      | dateFrom   | dateTo     | reason      | reasonDesc | suppressionChargeDescription | checkPeriodEnd |
-      | 2024-03-01 | 2024-03-20 | LEGISLATIVE | COVID      | SA-Suppression               | true           |
-    When suppression configuration is sent to ifs service
-    And a debt item
-      | originalAmount | interestStartDate | interestRequestedTo | mainTrans | subTrans | periodEnd  |
-      | 500000         | 2024-03-01        | 2024-07-06          | 1535      | 1000     | 2024-03-01 |
-    And the debt item has no payment history
-    And no breathing spaces have been applied to the debt item
-    And the customer has post codes
-      | postCode | postCodeDate |
-      | EC2M 2LS | 2019-07-06   |
-    When the debt item is sent to the ifs service
-    Then the ifs service wilL return a total debts summary of
-      | combinedDailyAccrual | interestDueCallTotal | amountIntTotal | unpaidAmountTotal |
-      | 88                   | 9590                 | 509590         | 500000            |
-    And the 1st debt summary will contain
-      | interestBearing | numberChargeableDays | interestDueDailyAccrual | interestDueDutyTotal | unpaidAmountDuty | totalAmountIntDuty | amountOnIntDueDuty |
-      | true            | 108                  | 88                      | 9590                 | 500000           | 509590             | 500000             |
-    And the 1st debt summary will have calculation windows
-      | periodFrom | periodTo   | numberOfDays | interestRate | interestDueDailyAccrual | unpaidAmountWindow | breathingSpaceApplied | reason      | description | code                                 |
-      | 2024-03-01 | 2024-03-20 | 19           | 0.0          | 0                       | 500000             | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
-      | 2024-03-21 | 2024-07-06 | 108          | 6.5          | 88                      | 509590             | false                 |             |             |                                      |
-
-
   Scenario: Suppression, 2 payments on different dates during suppression
     Given suppression configuration data is created
       | dateFrom   | dateTo     | reason      | reasonDesc | suppressionChargeDescription | mainTrans | subTrans | postcode | checkPeriodEnd | testRegime                                                                                              |
@@ -330,45 +303,6 @@ Feature: Suppression
       | 2021-02-01 | 2021-04-03 | 61           | 2.6          | 35                      | 2172              | 502172             | 500000               | false                 |             |             |                                      |
       | 2021-04-04 | 2021-05-04 | 31           | 0.0          | 0                       | 0                 | 500000             | 500000               | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
       | 2021-05-05 | 2021-07-06 | 63           | 2.6          | 35                      | 2243              | 502243             | 500000               | false                 |             |             |                                      |
-
-
-  Scenario: Suppression applied by all criteria on a single debt item.
-    Given suppression configuration data is created
-      | dateFrom   | dateTo     | reason      | reasonDesc | suppressionChargeDescription | subTrans | mainTrans | checkPeriodEnd | postcode |
-      | 2022-01-07 | 2022-01-20 | SUBTRANS    | COVID      | SA-Suppression               | 1000     |           |                |          |
-      | 2022-02-07 | 2022-02-20 | MAINTRANS   | COVID      | SA-Suppression               |          | 1535      |                |          |
-      | 2022-03-07 | 2022-03-20 | PERIODEND   | COVID      | SA-Suppression               |          |           | true           |          |
-      | 2022-04-07 | 2022-04-20 | LEGISLATIVE | COVID      | SA-Suppression               |          |           |                | EC2M 2LS |
-    When suppression configuration is sent to ifs service
-    And a debt item
-      | originalAmount | interestStartDate | interestRequestedTo | mainTrans | subTrans | periodEnd  |
-      | 500000         | 2022-01-01        | 2022-07-06          | 1535      | 1000     | 2022-03-09 |
-    And the debt item has no payment history
-    And no breathing spaces have been applied to the debt item
-    And the customer has post codes
-      | postCode | postCodeDate |
-      | EC2M 2LS | 2022-01-01   |
-    When the debt item is sent to the ifs service
-    Then the ifs service wilL return a total debts summary of
-      | combinedDailyAccrual | interestDueCallTotal | amountIntTotal | unpaidAmountTotal | amountOnIntDueTotal |
-      | 51                   | 5682                 | 505682         | 500000            | 500000              |
-    And the 1st debt summary will contain
-      | interestBearing | numberChargeableDays | interestDueDailyAccrual | interestDueDutyTotal | unpaidAmountDuty | totalAmountIntDuty | amountOnIntDueDuty |
-      | true            | 130                  | 51                      | 5682                 | 500000           | 505682             | 500000             |
-    And the 1st debt summary will have calculation windows
-      | periodFrom | periodTo   | numberOfDays | interestRate | interestDueDailyAccrual | interestDueWindow | unpaidAmountWindow | amountOnIntDueWindow | breathingSpaceApplied | reason      | description | code                                 |
-      | 2022-01-01 | 2022-01-06 | 5            | 2.6          | 35                      | 178               | 500178             | 500000               | false                 |             |             |                                      |
-      | 2022-01-07 | 2022-01-20 | 14           | 0.0          | 0                       | 0                 | 500000             | 500000               | false                 | SUBTRANS    | COVID       | Converted from new suppression style |
-      | 2022-01-21 | 2022-02-06 | 17           | 2.75         | 37                      | 640               | 500640             | 500000               | false                 |             |             |                                      |
-      | 2022-02-07 | 2022-02-20 | 14           | 0.0          | 0                       | 0                 | 500000             | 500000               | false                 | MAINTRANS   | COVID       | Converted from new suppression style |
-      | 2022-02-21 | 2022-03-06 | 14           | 3.0          | 41                      | 575               | 500575             | 500000               | false                 |             |             |                                      |
-      | 2022-03-07 | 2022-03-20 | 14           | 0.0          | 0                       | 0                 | 500000             | 500000               | false                 | PERIODEND   | COVID       | Converted from new suppression style |
-      | 2022-03-21 | 2022-04-04 | 15           | 3.0          | 41                      | 616               | 500616             | 500000               | false                 |             |             |                                      |
-      | 2022-04-05 | 2022-04-06 | 2            | 3.25         | 44                      | 89                | 500089             | 500000               | false                 |             |             |                                      |
-      | 2022-04-07 | 2022-04-20 | 14           | 0.0          | 0                       | 0                 | 500000             | 500000               | false                 | LEGISLATIVE | COVID       | Converted from new suppression style |
-      | 2022-04-21 | 2022-05-23 | 33           | 3.25         | 44                      | 1469              | 501469             | 500000               | false                 |             |             |                                      |
-      | 2022-05-24 | 2022-07-04 | 42           | 3.5          | 47                      | 2013              | 502013             | 500000               | false                 |             |             |                                      |
-      | 2022-07-05 | 2022-07-06 | 2            | 3.75         | 51                      | 102               | 500102             | 500000               | false                 |             |             |                                      |
 
   @DTD-3325
   Scenario: Suppression applied by all criteria on 2 debt items.

--- a/src/test/resources/features/ifs/fieldCollectionsIFS/FCMultipeDebtItems.feature
+++ b/src/test/resources/features/ifs/fieldCollectionsIFS/FCMultipeDebtItems.feature
@@ -147,44 +147,6 @@ Feature: FC Debt Calculation End point testing
       | 2018-12-16 | 2019-02-03 | 49           | 3.25         | 44                      | 502181             |
 
 
-  Scenario: 7. Total Payments cannot be 0.
-    Given a fc debt item
-      | originalAmount | interestStartDate | interestRequestedTo | interestIndicator | periodEnd  | debtId |
-      | 500000         | 2018-12-16        | 2019-04-14          | Y                 | 2018-04-06 | 123    |
-    And the debt item has fc payment history
-      | paymentAmount | paymentDate |
-      | 0             | 2019-02-03  |
-    And no breathing spaces have been applied to the fc debt item
-    And the fc customer has no post codes
-    When the debt item is sent to the fc ifs service
-    Then the fc ifs service will respond with Could not parse body due to requirement failed: Payment amount must not be zero
-
-  Scenario: 8. Total Payments cannot be negative.
-    Given a fc debt item
-      | originalAmount | interestStartDate | interestRequestedTo | interestIndicator | periodEnd  | debtId |
-      | 500000         | 2018-12-16        | 2019-04-14          | Y                 | 2018-04-06 | 123    |
-    And the debt item has fc payment history
-      | paymentAmount | paymentDate |
-      | -1000         | 2019-02-03  |
-    And no breathing spaces have been applied to the fc debt item
-    And the fc customer has no post codes
-    When the debt item is sent to the fc ifs service
-    Then the fc ifs service will respond with Could not parse body due to requirement failed: Payment amount must be positive
-
-
-  Scenario: 9. Total Payment amounts cannot be more than the original amount.
-    Given a fc debt item
-      | originalAmount | interestStartDate | interestRequestedTo | interestIndicator | periodEnd  | debtId |
-      | 500000         | 2018-12-16        | 2019-04-14          | Y                 | 2018-04-06 | 123    |
-    And the debt item has fc payment history
-      | paymentAmount | paymentDate |
-      | 555555        | 2019-02-03  |
-    And no breathing spaces have been applied to the fc debt item
-    And the fc customer has no post codes
-    When the debt item is sent to the fc ifs service
-    Then the fc ifs service will respond with Could not parse body due to requirement failed: Total Payment amounts cannot be more than the original amount
-
-
   Scenario: 10. No InterestStartDate but InterestIndicator is Yes.
     Given a fc debt item
       | originalAmount | interestStartDate | interestRequestedTo | interestIndicator | periodEnd  | debtId |


### PR DESCRIPTION
As part of the shift-left analysis a few duplicated tests were identified, so these have been removed prior to the scalaTest migration.